### PR TITLE
fix Demo: add frame to red color View

### DIFF
--- a/HaloDemo/ViewController.swift
+++ b/HaloDemo/ViewController.swift
@@ -17,6 +17,7 @@ extension ViewController {
             .superView(view)
             .backgroundColor(Red)
             .cornerRadius(5, borderWidth: 1, borderColor: Red.alpha(0.5))
+            .frame(x: 100, y: 100, width: 100, height: 100)
     }
     
     override func viewWillLayoutSubviews() {


### PR DESCRIPTION
Demo 中红色的 View 因为没有位置而不能显示，我给他添加了

``` objc
.frame(x: 100, y: 100, width: 100, height: 100)
```

来解决这个问题，效果如图（是不是该引入你的 `FangYuan` 来做这件事情了 2333）

![Screenshot](http://ww4.sinaimg.cn/large/0060lm7Tgw1f3cqj71iv6j30h90uoq37.jpg)
